### PR TITLE
Add support for Danbooru + custom User-Agents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,6 +1553,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1582,7 +1582,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wallpaper-dl"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "apputils",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ publish = true
 
 [dependencies]
 apputils = "0.1"
-url = "2.5"
+url = { version = "2.5", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 reqwest = { version = "0.12", features = ["blocking", "rustls-tls-native-roots", "deflate", "gzip", "brotli", "json", "charset"], default-features = false }
 scraper = "0.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wallpaper-dl"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "EUPL-1.2"
 readme = "README.md"

--- a/src/downloaders/alphacoders.rs
+++ b/src/downloaders/alphacoders.rs
@@ -49,8 +49,8 @@ impl Alphacoders {
 /// Downloader designed for [Wallpaper Abyss](https://wall.alphacoders.com/)
 pub struct WallpaperAbyss(Alphacoders);
 
+#[allow(refining_impl_trait)]
 impl Downloader for WallpaperAbyss {
-	#[allow(refining_impl_trait)]
 	fn new(client: &Client, url: Url) -> DownloaderResult<Self> {
 		let id = match url.query() {
 			Some(x) => x.replace("i=", ""),

--- a/src/downloaders/artstation.rs
+++ b/src/downloaders/artstation.rs
@@ -12,8 +12,8 @@ pub struct ArtStation {
 	assets: Vec<Asset>
 }
 
+#[allow(refining_impl_trait)]
 impl Downloader for ArtStation {
-	#[allow(refining_impl_trait)]
 	fn new(client: &Client, mut url: Url) -> DownloaderResult<Self> {
 		let id_path = url.path().replace("/artwork/", "/projects/");
 		let api_path = format!("{}.json", id_path);

--- a/src/downloaders/danbooru.rs
+++ b/src/downloaders/danbooru.rs
@@ -1,0 +1,21 @@
+use super::{quick_get, Downloader, DownloaderError, DownloaderResult, ScraperWrapper, SelectAttr, Urls};
+use reqwest::blocking::Client;
+use scraper::Html;
+use url::Url;
+
+pub struct Danbooru;
+
+#[allow(refining_impl_trait)]
+impl Downloader for Danbooru {
+	fn new(client: &Client, url: Url) -> DownloaderResult<Self> {
+		todo!()
+	}
+
+	fn image_id(&self) -> &str {
+		todo!()
+	}
+
+	fn image_url(&self) -> DownloaderResult<Urls> {
+		todo!()
+	}
+}

--- a/src/downloaders/danbooru.rs
+++ b/src/downloaders/danbooru.rs
@@ -1,21 +1,43 @@
-use super::{quick_get, Downloader, DownloaderError, DownloaderResult, ScraperWrapper, SelectAttr, Urls};
+use super::{quick_get, Downloader, DownloaderResult, Urls};
 use reqwest::blocking::Client;
-use scraper::Html;
+use serde::Deserialize;
 use url::Url;
 
-pub struct Danbooru;
+#[derive(Deserialize)]
+pub struct DanbooruApi {
+	id: u32,
+	file_url: Url
+}
+
+pub struct Danbooru {
+	id: String,
+	file_url: Url
+}
+
+impl From<DanbooruApi> for Danbooru {
+	fn from(value: DanbooruApi) -> Danbooru {
+		Danbooru {
+			file_url: value.file_url,
+			id: value.id.to_string()
+		}
+	}
+}
 
 #[allow(refining_impl_trait)]
 impl Downloader for Danbooru {
-	fn new(client: &Client, url: Url) -> DownloaderResult<Self> {
-		todo!()
-	}
+	fn new(client: &Client, mut url: Url) -> DownloaderResult<Self> {
+		// Append .json extension
+		let newpath = format!("{}.json", url.path());
+		url.set_path(&newpath);
 
+		// Make API Request
+		let api_res = quick_get(client, url)?.json::<DanbooruApi>()?;
+		Ok(api_res.into())
+	}
 	fn image_id(&self) -> &str {
-		todo!()
+		&self.id
 	}
-
 	fn image_url(&self) -> DownloaderResult<Urls> {
-		todo!()
+		Ok(self.file_url.clone().into())
 	}
 }

--- a/src/downloaders/mod.rs
+++ b/src/downloaders/mod.rs
@@ -12,11 +12,12 @@ use url::{ParseError, Url};
 mod alphacoders;
 mod artstation;
 mod wallhaven;
+mod danbooru;
 
 pub use alphacoders::{ArtAbyss, ImageAbyss, WallpaperAbyss};
 pub use artstation::ArtStation;
 pub use wallhaven::Wallhaven;
-
+pub use danbooru::Danbooru;
 
 macro_rules! ok_box {
 	($dl:expr) => {
@@ -29,6 +30,7 @@ const WALLPAPER_ABYSS: &str = "wall.alphacoders.com";
 const ART_ABYSS: &str = "art.alphacoders.com";
 const IMAGE_ABYSS: &str = "pics.alphacoders.com";
 const ARTSTATION: &str = "www.artstation.com";
+const DANBOORU: &str = "danbooru.donmai.us";
 
 /// [Downloader] from URL
 ///
@@ -42,6 +44,7 @@ pub fn from_url(c: &Client, url: Url) -> DownloaderResult<Box<dyn Downloader>> {
 		ART_ABYSS => ok_box!(ArtAbyss::new(c, url)),
 		IMAGE_ABYSS => ok_box!(ImageAbyss::new(c, url)),
 		ARTSTATION => ok_box!(ArtStation::new(c, url)),
+		DANBOORU => ok_box!(Danbooru::new(c, url)),
 		_ => Err(DownloaderError::Other)
 	}
 }

--- a/src/downloaders/wallhaven.rs
+++ b/src/downloaders/wallhaven.rs
@@ -34,8 +34,8 @@ pub struct Wallhaven {
 	id: String
 }
 
+#[allow(refining_impl_trait)]
 impl Downloader for Wallhaven {
-	#[allow(refining_impl_trait)]
 	fn new(client: &Client, mut url: Url) -> DownloaderResult<Self> {
 		let api_path = format!("/api/v1{}", url.path());
 		url.set_path(&api_path);

--- a/src/downloaders/wallhaven.rs
+++ b/src/downloaders/wallhaven.rs
@@ -3,23 +3,6 @@ use reqwest::blocking::Client;
 use serde::Deserialize;
 use url::Url;
 
-#[derive(Deserialize, Clone)]
-struct Tag {
-	category: String,
-	name: String,
-	alias: String,
-}
-
-impl From<Tag> for Vec<String> {
-	fn from(value: Tag) -> Vec<String> {
-		let mut tags = vec![value.category, value.name];
-		value.alias
-			.split(", ")
-			.for_each(|x| tags.push(x.to_string()));
-		tags
-	}
-}
-
 #[derive(Deserialize)]
 struct WallhavenApi {
 	data: Wallhaven,
@@ -30,7 +13,7 @@ struct WallhavenApi {
 /// Downloader designed for [Wallhaven](https://wallhaven.cc/)
 #[derive(Deserialize)]
 pub struct Wallhaven {
-	path: String,
+	path: Url,
 	id: String
 }
 
@@ -42,12 +25,10 @@ impl Downloader for Wallhaven {
 		let api_res = quick_get(client, url)?.json::<WallhavenApi>()?;
 		Ok(api_res.data)
 	}
-
 	fn image_id(&self) -> &str {
 		&self.id
 	}
 	fn image_url(&self) -> DownloaderResult<Urls> {
-		let url = Url::parse(&self.path)?;
-		Ok(url.into())
+		Ok(self.path.clone().into())
 	}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,9 +135,9 @@ fn download(client: &Client, url: Url, id: &str, host: &str, ctr: (bool, u8)) ->
 
 	// Build filename
 	let fname = if ctr.0 {
-		format!("{id}_{host}.{ext}")
+		format!("{host}_{id}.{ext}")
 	} else {
-		format!("{id}_{}_{host}.{ext}", ctr.1)
+		format!("{host}_{id}_{}.{ext}", ctr.1)
 	};
 
 	// Download file data

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ fn action(urls: Vec<Url>) -> ExitCode {
 			Ok(x) => x,
 			Err(err) => {
 				match err {
-					DownloaderError::Other => paint!(Colors::YellowBold, " Not Supported!"),
+					DownloaderError::Other => paintln!(Colors::YellowBold, " Not Supported!"),
 					_ => paintln!(Colors::RedBold, " Failed: {}{err}", Colors::Red)
 				};
 				continue;

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -11,7 +11,7 @@ pub const APP_NAME: &str = env!("CARGO_PKG_NAME");
 const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 const APP_DESC: &str = env!("CARGO_PKG_DESCRIPTION");
 
-// HTTP Constants
+// User-Agent
 pub const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), '/', env!("CARGO_PKG_VERSION"));
 
 pub struct Info;


### PR DESCRIPTION
Kind of felt like *not* making an issue for this. While it does not focus on sensitive content, it surely is known for it.

#### These are the changes I made:
- added submodule for Danbooru itself (too easy because I found out it has a REST API)
- fixed a missing newline when a given URL is not supported
- enabled `Serde` support for the `Url` crate
- removed unused code, e.g. struct `Tag` in Wallhaven

I also want to address issue #15 in this pull request, because this will ultimately become version 0.2.1 so it will close #15 too.